### PR TITLE
Add lxcfs for containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 Docker infrastructure used by the nZombies Chronicles community. Runs a database, various web apps and a few game servers. Intended to run on a single host, but nothing's stopping you from using thirdparty tools to set it up on multiple hosts.
 
 ## Prerequisites
-* a Linux install on baremetal or inside a virtual machine with at least 25GB of free disk space and 3GB of RAM available
+* a Linux install (outside of a container) with at least 4 CPU threads (for best performance), 25GB of free disk space and 3GB of RAM available.
 * a domain
 
 Packages:
 * docker with a minimum version of 24.0.0, build 98fdcd769b
 * docker-compose with a minimum version of 2.18.1
+* lxcfs
 * envsubst
 * iptables
 * make
@@ -18,6 +19,12 @@ Check your versions:
 * `docker-compose -v`
 
 You can possibly use earlier versions, but if things don't work as expected - that's why.
+
+Make sure lxcfs is running:
+* `sudo systemctl enable lxcfs --now`
+* `find /var/lib/lxcfs/` You should be seeing many files listed for things like cpu and whatnot
+
+We use lxcfs so that the containerized programs can see the container's resources rather than the host's resources, which helps with performance particularly with Nginx and MySQL. If you don't care and don't want to use lxcfs, you can remove the lxcfs volume mappings from all YAML files.
 
 ## Installing
 * `git clone https://github.com/Ethorbit/nzombies-chronicles-docker.git`
@@ -37,10 +44,10 @@ Everything runs on a single machine, so edit: `.limits.env`
 
 IO limits are applied only to the disk device set by `DISK`. This is because all IO heavy operations take place in volumes, and there is (or should only be) one disk for volumes.
 
-Change which CPU cores each service runs off of. It is already optimized for a 2 core system by default.
+Change which CPU threads each service runs off of. It is already optimized for a system with a maximum of 4 threads by default.
 Keep in mind that Garry's Mod and Sven Co-op are single-threaded.
 
-Note that IO speed limits, RAM limits, and CPU weights are already configured in the yaml files with no variables provided, they should already be optimized well enough.
+Note that IO speed limits, RAM limits and CPU weights are already configured in the yaml files with no variables provided, they should already be optimized well enough.
 
 ## Configuring
 

--- a/compose/discord-bots.yml
+++ b/compose/discord-bots.yml
@@ -32,6 +32,14 @@ services:
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro
+      - /var/lib/lxcfs/proc/cpuinfo:/proc/cpuinfo:rw
+      - /var/lib/lxcfs/proc/diskstats:/proc/diskstats:rw
+      - /var/lib/lxcfs/proc/meminfo:/proc/meminfo:rw
+      - /var/lib/lxcfs/proc/stat:/proc/stat:rw
+      - /var/lib/lxcfs/proc/swaps:/proc/swaps:rw
+      - /var/lib/lxcfs/proc/uptime:/proc/uptime:rw
+      - /var/lib/lxcfs/proc/slabinfo:/proc/slabinfo:rw
+      - /var/lib/lxcfs/sys/devices/system/cpu:/sys/devices/system/cpu:rw
       - ./data/configs/users/passwd:/etc/passwd:ro
       - ./data/configs/users/group:/etc/group:ro
       - ./data/configs/users/shadow:/etc/shadow:ro

--- a/compose/gmod_servers.yml
+++ b/compose/gmod_servers.yml
@@ -86,6 +86,14 @@ x-gmod_1: &gmod_1
     - ./data/configs/users/group:/etc/group:ro
     - ./data/configs/users/shadow:/etc/shadow:ro
     - ./data/configs/users/gshadow:/etc/gshadow:ro
+    - /var/lib/lxcfs/proc/cpuinfo:/proc/cpuinfo:rw
+    - /var/lib/lxcfs/proc/diskstats:/proc/diskstats:rw
+    - /var/lib/lxcfs/proc/meminfo:/proc/meminfo:rw
+    - /var/lib/lxcfs/proc/stat:/proc/stat:rw
+    - /var/lib/lxcfs/proc/swaps:/proc/swaps:rw
+    - /var/lib/lxcfs/proc/uptime:/proc/uptime:rw
+    - /var/lib/lxcfs/proc/slabinfo:/proc/slabinfo:rw
+    - /var/lib/lxcfs/sys/devices/system/cpu:/sys/devices/system/cpu:rw
     - gmod_1:/home/steam/server:slave
     - gmod_shared:/shared:slave
   ports:
@@ -116,6 +124,14 @@ x-gmod_2: &gmod_2
     - ./data/configs/users/group:/etc/group:ro
     - ./data/configs/users/shadow:/etc/shadow:ro
     - ./data/configs/users/gshadow:/etc/gshadow:ro
+    - /var/lib/lxcfs/proc/cpuinfo:/proc/cpuinfo:rw
+    - /var/lib/lxcfs/proc/diskstats:/proc/diskstats:rw
+    - /var/lib/lxcfs/proc/meminfo:/proc/meminfo:rw
+    - /var/lib/lxcfs/proc/stat:/proc/stat:rw
+    - /var/lib/lxcfs/proc/swaps:/proc/swaps:rw
+    - /var/lib/lxcfs/proc/uptime:/proc/uptime:rw
+    - /var/lib/lxcfs/proc/slabinfo:/proc/slabinfo:rw
+    - /var/lib/lxcfs/sys/devices/system/cpu:/sys/devices/system/cpu:rw
     - gmod_2:/home/steam/server:slave
     - gmod_shared:/shared:slave
   ports:
@@ -146,6 +162,14 @@ x-gmod_3: &gmod_3
     - ./data/configs/users/group:/etc/group:ro
     - ./data/configs/users/shadow:/etc/shadow:ro
     - ./data/configs/users/gshadow:/etc/gshadow:ro
+    - /var/lib/lxcfs/proc/cpuinfo:/proc/cpuinfo:rw
+    - /var/lib/lxcfs/proc/diskstats:/proc/diskstats:rw
+    - /var/lib/lxcfs/proc/meminfo:/proc/meminfo:rw
+    - /var/lib/lxcfs/proc/stat:/proc/stat:rw
+    - /var/lib/lxcfs/proc/swaps:/proc/swaps:rw
+    - /var/lib/lxcfs/proc/uptime:/proc/uptime:rw
+    - /var/lib/lxcfs/proc/slabinfo:/proc/slabinfo:rw
+    - /var/lib/lxcfs/sys/devices/system/cpu:/sys/devices/system/cpu:rw
     - gmod_3:/home/steam/server:slave
     - gmod_shared:/shared:slave
   ports:

--- a/compose/mysql.yml
+++ b/compose/mysql.yml
@@ -35,6 +35,14 @@ services:
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro
+      - /var/lib/lxcfs/proc/cpuinfo:/proc/cpuinfo:rw
+      - /var/lib/lxcfs/proc/diskstats:/proc/diskstats:rw
+      - /var/lib/lxcfs/proc/meminfo:/proc/meminfo:rw
+      - /var/lib/lxcfs/proc/stat:/proc/stat:rw
+      - /var/lib/lxcfs/proc/swaps:/proc/swaps:rw
+      - /var/lib/lxcfs/proc/uptime:/proc/uptime:rw
+      - /var/lib/lxcfs/proc/slabinfo:/proc/slabinfo:rw
+      - /var/lib/lxcfs/sys/devices/system/cpu:/sys/devices/system/cpu:rw
       - mysql:/var/lib/mysql
       - ./data/configs/mysql/init.sql:/docker-entrypoint-initdb.d/init.sql
       - ./data/configs/mysql/mysql.cnf:/etc/mysql/conf.d/mysql.cnf
@@ -57,6 +65,14 @@ services:
       nofile:
         soft: 20000
         hard: 40000
+    cpuset: ${MYSQL_CPU}
+    cpu_shares: 1024
+    deploy:
+      resources:
+        limits:
+          memory: 2048M
+        reservations:
+          memory: 512M
     blkio_config:
       weight: 1000
       device_write_bps:

--- a/compose/nginx.yml
+++ b/compose/nginx.yml
@@ -38,7 +38,7 @@ x-nginx: &nginx
     timeout: 10s
     retries: 3
   cpuset: ${NGINX_CPU}
-  cpu_shares: 2048
+  cpu_shares: 1024
   deploy:
     resources:
       limits:
@@ -228,7 +228,15 @@ services:
       - ./data/configs/users/group:/etc/group:ro
       - ./data/configs/users/shadow:/etc/shadow:ro 
       - ./data/configs/users/gshadow:/etc/gshadow:ro
-      - ./data/configs/nginx/cpu/online:/sys/devices/system/cpu/online:ro
+      # - ./data/configs/nginx/cpu/online:/sys/devices/system/cpu/online:ro
+      - /var/lib/lxcfs/proc/cpuinfo:/proc/cpuinfo:rw
+      - /var/lib/lxcfs/proc/diskstats:/proc/diskstats:rw
+      - /var/lib/lxcfs/proc/meminfo:/proc/meminfo:rw
+      - /var/lib/lxcfs/proc/stat:/proc/stat:rw
+      - /var/lib/lxcfs/proc/swaps:/proc/swaps:rw
+      - /var/lib/lxcfs/proc/uptime:/proc/uptime:rw
+      - /var/lib/lxcfs/proc/slabinfo:/proc/slabinfo:rw
+      - /var/lib/lxcfs/sys/devices/system/cpu:/sys/devices/system/cpu:rw
       - php_fpm_run:/var/run/php-fpm
       - nginx_cache:/mnt/cache
       - nginx_websites:/mnt/websites
@@ -274,7 +282,15 @@ services:
       - ./data/configs/users/group:/etc/group:ro
       - ./data/configs/users/shadow:/etc/shadow:ro 
       - ./data/configs/users/gshadow:/etc/gshadow:ro
-      - ./data/configs/nginx/cpu/online:/sys/devices/system/cpu/online:ro
+      # - ./data/configs/nginx/cpu/online:/sys/devices/system/cpu/online:ro
+      - /var/lib/lxcfs/proc/cpuinfo:/proc/cpuinfo:rw
+      - /var/lib/lxcfs/proc/diskstats:/proc/diskstats:rw
+      - /var/lib/lxcfs/proc/meminfo:/proc/meminfo:rw
+      - /var/lib/lxcfs/proc/stat:/proc/stat:rw
+      - /var/lib/lxcfs/proc/swaps:/proc/swaps:rw
+      - /var/lib/lxcfs/proc/uptime:/proc/uptime:rw
+      - /var/lib/lxcfs/proc/slabinfo:/proc/slabinfo:rw
+      - /var/lib/lxcfs/sys/devices/system/cpu:/sys/devices/system/cpu:rw
       - php_fpm_run:/var/run/php-fpm
       - nginx_cache:/mnt/cache
       - nginx_websites:/mnt/websites

--- a/compose/php_fpm.yml
+++ b/compose/php_fpm.yml
@@ -27,7 +27,15 @@ x-php_fpm: &php_fpm
     - ./data/configs/users/group:/etc/group:ro
     - ./data/configs/users/shadow:/etc/shadow:ro 
     - ./data/configs/users/gshadow:/etc/gshadow:ro
-    - ./data/configs/nginx/cpu/online:/sys/devices/system/cpu/online:ro
+    #- ./data/configs/nginx/cpu/online:/sys/devices/system/cpu/online:ro
+    - /var/lib/lxcfs/proc/cpuinfo:/proc/cpuinfo:rw
+    - /var/lib/lxcfs/proc/diskstats:/proc/diskstats:rw
+    - /var/lib/lxcfs/proc/meminfo:/proc/meminfo:rw
+    - /var/lib/lxcfs/proc/stat:/proc/stat:rw
+    - /var/lib/lxcfs/proc/swaps:/proc/swaps:rw
+    - /var/lib/lxcfs/proc/uptime:/proc/uptime:rw
+    - /var/lib/lxcfs/proc/slabinfo:/proc/slabinfo:rw
+    - /var/lib/lxcfs/sys/devices/system/cpu:/sys/devices/system/cpu:rw
     - ./data/configs/php_fpm/www.conf:/usr/local/etc/php-fpm.d/www.conf
     - php_fpm_run:/var/run/php-fpm
     - nginx_websites:/mnt/websites
@@ -41,7 +49,7 @@ x-php_fpm: &php_fpm
     && chmod 770 /var/run/php-fpm/sock
     && php-fpm"
   cpuset: ${NGINX_CPU} # Since we handle the workloads of php (which is closely tied to webserver), we might as well use the same cores..
-  cpu_shares: 2048
+  cpu_shares: 1024
   # Website PHP scripts are actually logged to nginx, this only logs the php-fpm process itself (so kinda useless)
   depends_on:
     rsyslog:

--- a/compose/portainer.yml
+++ b/compose/portainer.yml
@@ -7,6 +7,14 @@ x-portainer: &portainer
   volumes:
     - /etc/localtime:/etc/localtime:ro
     - /etc/timezone:/etc/timezone:ro
+    - /var/lib/lxcfs/proc/cpuinfo:/proc/cpuinfo:rw
+    - /var/lib/lxcfs/proc/diskstats:/proc/diskstats:rw
+    - /var/lib/lxcfs/proc/meminfo:/proc/meminfo:rw
+    - /var/lib/lxcfs/proc/stat:/proc/stat:rw
+    - /var/lib/lxcfs/proc/swaps:/proc/swaps:rw
+    - /var/lib/lxcfs/proc/uptime:/proc/uptime:rw
+    - /var/lib/lxcfs/proc/slabinfo:/proc/slabinfo:rw
+    - /var/lib/lxcfs/sys/devices/system/cpu:/sys/devices/system/cpu:rw
     - /var/run/docker.sock:/var/run/docker.sock
     - portainer_data:/data
     - ./data/configs/portainer:/configs

--- a/compose/searxng.yml
+++ b/compose/searxng.yml
@@ -35,6 +35,15 @@ services:
     ports:
       - 127.0.0.1:${REDIS_PORT:-6379}:6379/tcp
     <<: [ *cpu-limits, *io-limits ]
+    volumes:
+      - /var/lib/lxcfs/proc/cpuinfo:/proc/cpuinfo:rw
+      - /var/lib/lxcfs/proc/diskstats:/proc/diskstats:rw
+      - /var/lib/lxcfs/proc/meminfo:/proc/meminfo:rw
+      - /var/lib/lxcfs/proc/stat:/proc/stat:rw
+      - /var/lib/lxcfs/proc/swaps:/proc/swaps:rw
+      - /var/lib/lxcfs/proc/uptime:/proc/uptime:rw
+      - /var/lib/lxcfs/proc/slabinfo:/proc/slabinfo:rw
+      - /var/lib/lxcfs/sys/devices/system/cpu:/sys/devices/system/cpu:rw
     restart: always
     deploy:
       resources:
@@ -74,6 +83,14 @@ services:
     ports:
       - 127.0.0.1:${SEARXNG_PORT:-8080}:8080/tcp
     volumes:
+      - /var/lib/lxcfs/proc/cpuinfo:/proc/cpuinfo:rw
+      - /var/lib/lxcfs/proc/diskstats:/proc/diskstats:rw
+      - /var/lib/lxcfs/proc/meminfo:/proc/meminfo:rw
+      - /var/lib/lxcfs/proc/stat:/proc/stat:rw
+      - /var/lib/lxcfs/proc/swaps:/proc/swaps:rw
+      - /var/lib/lxcfs/proc/uptime:/proc/uptime:rw
+      - /var/lib/lxcfs/proc/slabinfo:/proc/slabinfo:rw
+      - /var/lib/lxcfs/sys/devices/system/cpu:/sys/devices/system/cpu:rw
       - ./data/configs/searxng:/etc/searxng:rw
     cap_drop:
       - ALL

--- a/compose/sshd.yml
+++ b/compose/sshd.yml
@@ -65,6 +65,14 @@ services:
       - ./data/configs/users/group:/etc/group:ro
       - ./data/configs/users/shadow:/etc/shadow:ro
       - ./data/configs/users/gshadow:/etc/gshadow:ro
+      - /var/lib/lxcfs/proc/cpuinfo:/proc/cpuinfo:rw
+      - /var/lib/lxcfs/proc/diskstats:/proc/diskstats:rw
+      - /var/lib/lxcfs/proc/meminfo:/proc/meminfo:rw
+      - /var/lib/lxcfs/proc/stat:/proc/stat:rw
+      - /var/lib/lxcfs/proc/swaps:/proc/swaps:rw
+      - /var/lib/lxcfs/proc/uptime:/proc/uptime:rw
+      - /var/lib/lxcfs/proc/slabinfo:/proc/slabinfo:rw
+      - /var/lib/lxcfs/sys/devices/system/cpu:/sys/devices/system/cpu:rw
       - ./data/configs/ssh/sshd_config:/etc/ssh/sshd_config
       - sftp:/mnt
       - svencoop:/mnt/game_servers/svencoop
@@ -88,6 +96,7 @@ services:
           service_completed_successfully
       rsyslog:
         condition: service_healthy
+    cpuset: ${SSH_CPU}
     cpu_shares: 256
     deploy:
       resources:

--- a/compose/svencoop.yml
+++ b/compose/svencoop.yml
@@ -19,6 +19,14 @@ x-svencoop: &svencoop
     - ./data/configs/users/group:/etc/group:ro
     - ./data/configs/users/shadow:/etc/shadow:ro
     - ./data/configs/users/gshadow:/etc/gshadow:ro
+    - /var/lib/lxcfs/proc/cpuinfo:/proc/cpuinfo:rw
+    - /var/lib/lxcfs/proc/diskstats:/proc/diskstats:rw
+    - /var/lib/lxcfs/proc/meminfo:/proc/meminfo:rw
+    - /var/lib/lxcfs/proc/stat:/proc/stat:rw
+    - /var/lib/lxcfs/proc/swaps:/proc/swaps:rw
+    - /var/lib/lxcfs/proc/uptime:/proc/uptime:rw
+    - /var/lib/lxcfs/proc/slabinfo:/proc/slabinfo:rw
+    - /var/lib/lxcfs/sys/devices/system/cpu:/sys/devices/system/cpu:rw
     - svencoop:/home/steam/server
   ports:
     - ${SVENCOOP_PORT:-28015}:${SVENCOOP_PORT:-28015}/udp

--- a/install/.limits.env.template
+++ b/install/.limits.env.template
@@ -6,18 +6,20 @@ DISK=
 # CPU cores services are allowed to use
 # No reason to give GMOD or SVENCOOP more than one,
 # they are single-threaded applications.
-NGINX_CPU=1
+NGINX_CPU=0
 
-MYSQL_CPU="0-1"
+MYSQL_CPU="0-3"
 
-SEARXNG_CPU=1
+SSH_CPU="0-3"
 
-PORTAINER_CPU=1
+SEARXNG_CPU=0
 
-GMOD_1_CPU=0
-GMOD_2_CPU=0
-GMOD_3_CPU=0
+PORTAINER_CPU=0
 
-SVENCOOP_CPU=1
+GMOD_1_CPU=1
+GMOD_2_CPU=2
+GMOD_3_CPU=3
 
-DISCORD_CPU=1
+SVENCOOP_CPU=3
+
+DISCORD_CPU=0


### PR DESCRIPTION
Improves performance by allowing containerized applications to see the true resources available to a container rather than the total available on the host. This is optional and you can remove it by commenting out all the lxcfs bind mounts from all the yaml files.

Additionally the default optimizations have changed to support a system with 4 CPU threads. This is because we have learned that sharing gmod servers between threads is a terrible terrible idea and will only result in lots of lag. Keeping each game in their own thread offers the best performance.